### PR TITLE
Upgrade workbox to alpha and use InjectManifest plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,7 @@
     "jest": true
   },
   "rules": {
-    "no-underscore-dangle": [1, { "allow": ["_id", "__NAME__"] }],
+    "no-underscore-dangle": [1, { "allow": ["_id", "__NAME__", "__WB_MANIFEST"] }],
     "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "react/no-unescaped-entities": "off"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -68,6 +68,9 @@
     "tachyons-sass": "^4.9.5",
     "universal-cookie": "^4.0.0",
     "uuid": "^3.3.2",
+    "workbox-precaching": "^5.0.0-alpha.1",
+    "workbox-routing": "^5.0.0-alpha.1",
+    "workbox-strategies": "^5.0.0-alpha.1",
     "yup": "^0.27.0"
   },
   "devDependencies": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -68,6 +68,8 @@
     "tachyons-sass": "^4.9.5",
     "universal-cookie": "^4.0.0",
     "uuid": "^3.3.2",
+    "workbox-cacheable-response": "^5.0.0-alpha.1",
+    "workbox-expiration": "^5.0.0-alpha.1",
     "workbox-precaching": "^5.0.0-alpha.1",
     "workbox-routing": "^5.0.0-alpha.1",
     "workbox-strategies": "^5.0.0-alpha.1",

--- a/packages/app/src/serviceWorker.ts
+++ b/packages/app/src/serviceWorker.ts
@@ -1,0 +1,78 @@
+/* env: webworker */
+
+import { precacheAndRoute } from 'workbox-precaching'
+import {
+  networkFirst,
+  staleWhileRevalidate,
+  cacheFirst,
+  networkOnly,
+} from 'workbox-strategies'
+import { registerRoute } from 'workbox-routing'
+
+const JS_CSS_REGEX = /\.(?:js|css)$/
+const IMAGE_REGEX = /\.(?:png|gif|jpg|jpeg|webp|svg)$/
+
+declare global {
+  interface Window {
+    __WB_MANIFEST: { url: string; revision: string }[]
+  }
+}
+
+precacheAndRoute(self.__WB_MANIFEST, {})
+
+const networkFirstHandler = networkFirst({}).handle
+
+// api
+registerRoute(/_c/, networkFirstHandler)
+
+// google fonts
+registerRoute(
+  /^https:\/\/fonts\.googleapis\.com/,
+  staleWhileRevalidate({
+    cacheName: 'google-fonts-stylesheets',
+  }).handle
+)
+
+registerRoute(
+  /^https:\/\/fonts\.gstatic\.com/,
+  cacheFirst({
+    cacheName: 'google-fonts-webfonts',
+    cacheableResponse: {
+      statuses: [0, 200],
+    },
+    expiration: {
+      maxEntries: 20,
+      // cache for a year
+      maxAgeSeconds: 60 * 60 * 24 * 365,
+    },
+  }).handle
+)
+
+// image assets
+registerRoute(
+  IMAGE_REGEX,
+  cacheFirst({
+    cacheName: 'images',
+    expiration: {
+      maxEntries: 60,
+      // cache for 30 days
+      maxAgeSeconds: 60 * 60 * 24 * 30,
+    },
+  }).handle
+)
+
+// javascript and css
+registerRoute(
+  JS_CSS_REGEX,
+  (process.env.NODE_ENV === 'development' ? networkOnly : staleWhileRevalidate)(
+    {
+      cacheName: 'static-resources',
+    }
+  ).handle
+)
+
+if (process.env.NODE_ENV === 'development') {
+  registerRoute(/(__webpack_hmr|hot-update)/, networkOnly({}).handle)
+} else {
+  registerRoute(/^https:\/\/(www\.)?cramkle\.com/, networkFirstHandler)
+}

--- a/packages/app/src/serviceWorker.ts
+++ b/packages/app/src/serviceWorker.ts
@@ -1,6 +1,8 @@
 /* env: webworker */
 
 import { precacheAndRoute } from 'workbox-precaching'
+import { Plugin as CacheableResponsePlugin } from 'workbox-cacheable-response'
+import { Plugin as ExpirationPlugin } from 'workbox-expiration'
 import {
   NetworkFirst,
   StaleWhileRevalidate,
@@ -37,14 +39,16 @@ registerRoute(
   /^https:\/\/fonts\.gstatic\.com/,
   new CacheFirst({
     cacheName: 'google-fonts-webfonts',
-    cacheableResponse: {
-      statuses: [0, 200],
-    },
-    expiration: {
-      maxEntries: 20,
-      // cache for a year
-      maxAgeSeconds: 60 * 60 * 24 * 365,
-    },
+    plugins: [
+      new CacheableResponsePlugin({
+        statuses: [0, 200],
+      }),
+      new ExpirationPlugin({
+        maxEntries: 20,
+        // cache for a year
+        maxAgeSeconds: 60 * 60 * 24 * 365,
+      }),
+    ],
   }).handle
 )
 
@@ -53,11 +57,13 @@ registerRoute(
   IMAGE_REGEX,
   new CacheFirst({
     cacheName: 'images',
-    expiration: {
-      maxEntries: 60,
-      // cache for 30 days
-      maxAgeSeconds: 60 * 60 * 24 * 30,
-    },
+    plugins: [
+      new ExpirationPlugin({
+        maxEntries: 60,
+        // cache for 30 days
+        maxAgeSeconds: 60 * 60 * 24 * 30,
+      }),
+    ],
   }).handle
 )
 

--- a/packages/app/src/serviceWorker.ts
+++ b/packages/app/src/serviceWorker.ts
@@ -2,10 +2,10 @@
 
 import { precacheAndRoute } from 'workbox-precaching'
 import {
-  networkFirst,
-  staleWhileRevalidate,
-  cacheFirst,
-  networkOnly,
+  NetworkFirst,
+  StaleWhileRevalidate,
+  CacheFirst,
+  NetworkOnly,
 } from 'workbox-strategies'
 import { registerRoute } from 'workbox-routing'
 
@@ -20,7 +20,7 @@ declare global {
 
 precacheAndRoute(self.__WB_MANIFEST, {})
 
-const networkFirstHandler = networkFirst({}).handle
+const networkFirstHandler = new NetworkFirst().handle
 
 // api
 registerRoute(/_c/, networkFirstHandler)
@@ -28,14 +28,14 @@ registerRoute(/_c/, networkFirstHandler)
 // google fonts
 registerRoute(
   /^https:\/\/fonts\.googleapis\.com/,
-  staleWhileRevalidate({
+  new StaleWhileRevalidate({
     cacheName: 'google-fonts-stylesheets',
   }).handle
 )
 
 registerRoute(
   /^https:\/\/fonts\.gstatic\.com/,
-  cacheFirst({
+  new CacheFirst({
     cacheName: 'google-fonts-webfonts',
     cacheableResponse: {
       statuses: [0, 200],
@@ -51,7 +51,7 @@ registerRoute(
 // image assets
 registerRoute(
   IMAGE_REGEX,
-  cacheFirst({
+  new CacheFirst({
     cacheName: 'images',
     expiration: {
       maxEntries: 60,
@@ -64,15 +64,15 @@ registerRoute(
 // javascript and css
 registerRoute(
   JS_CSS_REGEX,
-  (process.env.NODE_ENV === 'development' ? networkOnly : staleWhileRevalidate)(
-    {
-      cacheName: 'static-resources',
-    }
-  ).handle
+  new (process.env.NODE_ENV === 'development'
+    ? NetworkOnly
+    : StaleWhileRevalidate)({
+    cacheName: 'static-resources',
+  }).handle
 )
 
 if (process.env.NODE_ENV === 'development') {
-  registerRoute(/(__webpack_hmr|hot-update)/, networkOnly({}).handle)
+  registerRoute(/(__webpack_hmr|hot-update)/, new NetworkOnly().handle)
 } else {
   registerRoute(/^https:\/\/(www\.)?cramkle\.com/, networkFirstHandler)
 }

--- a/packages/server/config/createWebpackConfig.ts
+++ b/packages/server/config/createWebpackConfig.ts
@@ -38,7 +38,7 @@ const getBaseWebpackConfig = (options?: Options): Configuration => {
   const { isServer = false, dev = false } = options || {}
 
   // Get environment variables to inject into our app.
-  const env = getClientEnvironment(isServer)
+  const env = getClientEnvironment({ isServer })
 
   const sassLoaderConfig = {
     loader: 'sass-loader',
@@ -171,7 +171,6 @@ const getBaseWebpackConfig = (options?: Options): Configuration => {
                   require.resolve('@babel/preset-typescript'),
                 ],
                 plugins: [
-                  dev && require.resolve('react-hot-loader/babel'),
                   [
                     require.resolve('babel-plugin-named-asset-import'),
                     {
@@ -187,6 +186,7 @@ const getBaseWebpackConfig = (options?: Options): Configuration => {
                   require.resolve('@babel/plugin-proposal-class-properties'),
                   require.resolve('@babel/plugin-syntax-dynamic-import'),
                   require.resolve('babel-plugin-macros'),
+                  !isServer && dev && require.resolve('react-hot-loader/babel'),
                 ].filter(Boolean),
                 // This is a feature of `babel-loader` for webpack (not Babel itself).
                 // It enables caching results in ./node_modules/.cache/babel-loader/

--- a/packages/server/config/env.ts
+++ b/packages/server/config/env.ts
@@ -62,7 +62,8 @@ interface Env {
   [key: string]: string
 }
 
-function getClientEnvironment(isServer = false) {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getClientEnvironment({ isServer = false, worker = false } = {}) {
   const baseEnv: Env = {
     // Useful for determining whether we’re running in production mode.
     // Most importantly, it switches React into the correct mode.
@@ -85,7 +86,9 @@ function getClientEnvironment(isServer = false) {
     'process.browser': JSON.stringify(!isServer),
     // TODO: find workaround so this doesn't affect the service worker
     // Allow browser-only and server-only code to be eliminated
-    //'typeof window': JSON.stringify(isServer ? 'undefined' : 'object'),
+    /*'typeof window': JSON.stringify(
+      isServer || worker ? 'undefined' : 'object'
+    ),*/
   }
 
   return { raw, stringified }

--- a/packages/server/config/env.ts
+++ b/packages/server/config/env.ts
@@ -84,11 +84,10 @@ function getClientEnvironment({ isServer = false, worker = false } = {}) {
       return env
     }, {}),
     'process.browser': JSON.stringify(!isServer),
-    // TODO: find workaround so this doesn't affect the service worker
     // Allow browser-only and server-only code to be eliminated
-    /*'typeof window': JSON.stringify(
+    'typeof window': JSON.stringify(
       isServer || worker ? 'undefined' : 'object'
-    ),*/
+    ),
   }
 
   return { raw, stringified }

--- a/packages/server/config/env.ts
+++ b/packages/server/config/env.ts
@@ -83,8 +83,9 @@ function getClientEnvironment(isServer = false) {
       return env
     }, {}),
     'process.browser': JSON.stringify(!isServer),
+    // TODO: find workaround so this doesn't affect the service worker
     // Allow browser-only and server-only code to be eliminated
-    'typeof window': JSON.stringify(isServer ? 'undefined' : 'object'),
+    //'typeof window': JSON.stringify(isServer ? 'undefined' : 'object'),
   }
 
   return { raw, stringified }

--- a/packages/server/config/paths.ts
+++ b/packages/server/config/paths.ts
@@ -31,6 +31,7 @@ const appDistPublic = path.join(distFolder, 'public')
 const appPublic = resolveApp('public')
 const appIndexJs = resolveModule(resolveApp, 'src/index')
 const appStartJs = resolveModule(resolveApp, 'src/start')
+const appServiceWorker = resolveModule(resolveApp, 'src/serviceWorker')
 const appPackageJson = resolveApp('package.json')
 const appSrc = resolveApp('src')
 const yarnLockFile = resolveApp('yarn.lock')
@@ -45,6 +46,7 @@ export {
   appPublic,
   appIndexJs,
   appStartJs,
+  appServiceWorker,
   appPackageJson,
   appSrc,
   yarnLockFile,

--- a/packages/server/config/webpack/workbox.ts
+++ b/packages/server/config/webpack/workbox.ts
@@ -1,84 +1,18 @@
-import { GenerateSW, GenerateSWOptions } from 'workbox-webpack-plugin'
+import { InjectManifest } from 'workbox-webpack-plugin'
 
 import { Options } from './types'
+import * as paths from '../paths'
 
 const JS_CSS_REGEX = /\.(?:js|css)$/
-const MAP_REGEX = /\.(?:map)$/
+const SOURCE_MAP_REGEX = /\.(?:map)$/
 const IMAGE_REGEX = /\.(?:png|gif|jpg|jpeg|webp|svg)$/
 
 export const createWorkboxPlugin = ({ dev }: Options) => {
-  const runtimeCaching: GenerateSWOptions['runtimeCaching'] = [
-    {
-      // api
-      urlPattern: /_c/,
-      handler: 'NetworkFirst',
-    },
-    {
-      urlPattern: /^https:\/\/fonts\.googleapis\.com/,
-      handler: 'StaleWhileRevalidate',
-      options: {
-        cacheName: 'google-fonts-stylesheets',
-      },
-    },
-    {
-      urlPattern: /^https:\/\/fonts\.gstatic\.com/,
-      handler: 'CacheFirst',
-      options: {
-        cacheName: 'google-fonts-webfonts',
-        cacheableResponse: {
-          statuses: [0, 200],
-        },
-        expiration: {
-          maxEntries: 20,
-          // cache for a year
-          maxAgeSeconds: 60 * 60 * 24 * 365,
-        },
-      },
-    },
-    {
-      // image assets
-      urlPattern: IMAGE_REGEX,
-      handler: 'CacheFirst',
-      options: {
-        cacheName: 'images',
-        expiration: {
-          maxEntries: 60,
-          // cache for 30 days
-          maxAgeSeconds: 60 * 60 * 24 * 30,
-        },
-      },
-    },
-    {
-      urlPattern: JS_CSS_REGEX,
-      handler: dev ? 'NetworkOnly' : 'StaleWhileRevalidate',
-      options: {
-        cacheName: 'static-resources',
-      },
-    },
-  ]
-
-  if (dev) {
-    runtimeCaching.concat([
-      {
-        urlPattern: /(__webpack_hmr|hot-update)/,
-        handler: 'NetworkOnly',
-      },
-    ])
-  } else {
-    runtimeCaching.concat([
-      {
-        urlPattern: /https:\/\/(www\.)?cramkle\.com/,
-        handler: 'NetworkFirst',
-      },
-    ])
-  }
-
-  return new GenerateSW({
+  return new InjectManifest({
+    swSrc: paths.appServiceWorker,
     swDest: 'public/service-worker.js',
-    importsDirectory: 'static',
-    runtimeCaching,
     exclude: dev
-      ? [JS_CSS_REGEX, IMAGE_REGEX, MAP_REGEX, new RegExp('hot-update')]
+      ? [JS_CSS_REGEX, IMAGE_REGEX, SOURCE_MAP_REGEX, new RegExp('hot-update')]
       : [],
   })
 }

--- a/packages/server/config/webpack/workbox.ts
+++ b/packages/server/config/webpack/workbox.ts
@@ -1,6 +1,8 @@
+import webpack from 'webpack'
 import { InjectManifest } from 'workbox-webpack-plugin'
 
 import { Options } from './types'
+import getClientEnvironment from '../env'
 import * as paths from '../paths'
 
 const JS_CSS_REGEX = /\.(?:js|css)$/
@@ -8,11 +10,17 @@ const SOURCE_MAP_REGEX = /\.(?:map)$/
 const IMAGE_REGEX = /\.(?:png|gif|jpg|jpeg|webp|svg)$/
 
 export const createWorkboxPlugin = ({ dev }: Options) => {
+  const workerEnv = getClientEnvironment({ worker: true })
+
   return new InjectManifest({
     swSrc: paths.appServiceWorker,
     swDest: 'public/service-worker.js',
     exclude: dev
       ? [JS_CSS_REGEX, IMAGE_REGEX, SOURCE_MAP_REGEX, new RegExp('hot-update')]
       : [],
+    // @ts-ignore
+    webpackCompilationPlugins: [
+      new webpack.DefinePlugin(workerEnv.stringified),
+    ],
   })
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -85,6 +85,6 @@
     "webpack-hot-middleware": "^2.25.0",
     "webpack-manifest-plugin": "^2.0.4",
     "webpack-node-externals": "^1.7.2",
-    "workbox-webpack-plugin": "^4.3.1"
+    "workbox-webpack-plugin": "^5.0.0-alpha.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,6 +44,13 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
+"@babel/code-frame@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
+  integrity sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
 "@babel/core@7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.3.tgz#198d6d3af4567be3989550d97e068de94503074f"
@@ -80,6 +87,26 @@
     debug "^4.1.0"
     json5 "^2.1.0"
     lodash "^4.17.11"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/core@^7.4.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.5.5.tgz#17b2686ef0d6bc58f963dddd68ab669755582c30"
+  integrity sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.5.5"
+    "@babel/helpers" "^7.5.5"
+    "@babel/parser" "^7.5.5"
+    "@babel/template" "^7.4.4"
+    "@babel/traverse" "^7.5.5"
+    "@babel/types" "^7.5.5"
+    convert-source-map "^1.1.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.13"
     resolve "^1.3.2"
     semver "^5.4.1"
     source-map "^0.5.0"
@@ -123,6 +150,17 @@
     "@babel/types" "^7.5.0"
     jsesc "^2.5.1"
     lodash "^4.17.11"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/generator@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.5.5.tgz#873a7f936a3c89491b43536d12245b626664e3cf"
+  integrity sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==
+  dependencies:
+    "@babel/types" "^7.5.5"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
@@ -191,6 +229,15 @@
     "@babel/types" "^7.4.4"
     lodash "^4.17.11"
 
+"@babel/helper-define-map@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz#3dec32c2046f37e09b28c93eb0b103fd2a25d369"
+  integrity sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/types" "^7.5.5"
+    lodash "^4.17.13"
+
 "@babel/helper-explode-assignable-expression@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz#537fa13f6f1674df745b0c00ec8fe4e99681c8f6"
@@ -228,6 +275,13 @@
   integrity sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==
   dependencies:
     "@babel/types" "^7.0.0"
+
+"@babel/helper-member-expression-to-functions@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz#1fb5b8ec4453a93c439ee9fe3aeea4a84b76b590"
+  integrity sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==
+  dependencies:
+    "@babel/types" "^7.5.5"
 
 "@babel/helper-module-imports@^7.0.0":
   version "7.0.0"
@@ -288,6 +342,16 @@
     "@babel/traverse" "^7.4.4"
     "@babel/types" "^7.4.4"
 
+"@babel/helper-replace-supers@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz#f84ce43df031222d2bad068d2626cb5799c34bc2"
+  integrity sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.5.5"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/traverse" "^7.5.5"
+    "@babel/types" "^7.5.5"
+
 "@babel/helper-simple-access@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz#65eeb954c8c245beaa4e859da6188f39d71e585c"
@@ -331,6 +395,15 @@
     "@babel/traverse" "^7.5.0"
     "@babel/types" "^7.5.0"
 
+"@babel/helpers@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.5.5.tgz#63908d2a73942229d1e6685bc2a0e730dde3b75e"
+  integrity sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==
+  dependencies:
+    "@babel/template" "^7.4.4"
+    "@babel/traverse" "^7.5.5"
+    "@babel/types" "^7.5.5"
+
 "@babel/highlight@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
@@ -349,6 +422,11 @@
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.5.0.tgz#3e0713dff89ad6ae37faec3b29dcfc5c979770b7"
   integrity sha512-I5nW8AhGpOXGCCNYGc+p7ExQIBxRFnS2fd/d862bNOKvmoEPjYPcfIjsfdy0ujagYOIYPczKgD9l3FsgTkAzKA==
+
+"@babel/parser@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.5.5.tgz#02f077ac8817d3df4a832ef59de67565e71cca4b"
+  integrity sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==
 
 "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.2.0"
@@ -420,6 +498,14 @@
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.4.tgz#250de35d867ce8260a31b1fdac6c4fc1baa99331"
   integrity sha512-KCx0z3y7y8ipZUMAEEJOyNi11lMb/FOPUjjB113tfowgw0c16EGYos7worCKBcUAh2oG+OBnoUhsnTSoLpV9uA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+
+"@babel/plugin-proposal-object-rest-spread@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz#61939744f71ba76a3ae46b5eea18a54c16d22e58"
+  integrity sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
@@ -544,6 +630,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     lodash "^4.17.11"
 
+"@babel/plugin-transform-block-scoping@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz#a35f395e5402822f10d2119f6f8e045e3639a2ce"
+  integrity sha512-82A3CLRRdYubkG85lKwhZB0WZoHxLGsJdux/cOVaJCJpvYFl1LVzAIFyRsa7CvXqW8rBM4Zf3Bfn8PHt5DP0Sg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    lodash "^4.17.13"
+
 "@babel/plugin-transform-classes@7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz#adc7a1137ab4287a555d429cc56ecde8f40c062c"
@@ -569,6 +663,20 @@
     "@babel/helper-optimise-call-expression" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-replace-supers" "^7.4.4"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    globals "^11.1.0"
+
+"@babel/plugin-transform-classes@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz#d094299d9bd680a14a2a0edae38305ad60fb4de9"
+  integrity sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-define-map" "^7.5.5"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.5.5"
     "@babel/helper-split-export-declaration" "^7.4.4"
     globals "^11.1.0"
 
@@ -757,6 +865,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-replace-supers" "^7.1.0"
+
+"@babel/plugin-transform-object-super@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz#c70021df834073c65eb613b8679cc4a381d1a9f9"
+  integrity sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.5.5"
 
 "@babel/plugin-transform-parameters@^7.4.3", "@babel/plugin-transform-parameters@^7.4.4":
   version "7.4.4"
@@ -1017,6 +1133,62 @@
     js-levenshtein "^1.1.3"
     semver "^5.5.0"
 
+"@babel/preset-env@^7.4.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.5.5.tgz#bc470b53acaa48df4b8db24a570d6da1fef53c9a"
+  integrity sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-async-generator-functions" "^7.2.0"
+    "@babel/plugin-proposal-dynamic-import" "^7.5.0"
+    "@babel/plugin-proposal-json-strings" "^7.2.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.5.5"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.4.4"
+    "@babel/plugin-syntax-async-generators" "^7.2.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.2.0"
+    "@babel/plugin-syntax-json-strings" "^7.2.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-transform-arrow-functions" "^7.2.0"
+    "@babel/plugin-transform-async-to-generator" "^7.5.0"
+    "@babel/plugin-transform-block-scoped-functions" "^7.2.0"
+    "@babel/plugin-transform-block-scoping" "^7.5.5"
+    "@babel/plugin-transform-classes" "^7.5.5"
+    "@babel/plugin-transform-computed-properties" "^7.2.0"
+    "@babel/plugin-transform-destructuring" "^7.5.0"
+    "@babel/plugin-transform-dotall-regex" "^7.4.4"
+    "@babel/plugin-transform-duplicate-keys" "^7.5.0"
+    "@babel/plugin-transform-exponentiation-operator" "^7.2.0"
+    "@babel/plugin-transform-for-of" "^7.4.4"
+    "@babel/plugin-transform-function-name" "^7.4.4"
+    "@babel/plugin-transform-literals" "^7.2.0"
+    "@babel/plugin-transform-member-expression-literals" "^7.2.0"
+    "@babel/plugin-transform-modules-amd" "^7.5.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.5.0"
+    "@babel/plugin-transform-modules-systemjs" "^7.5.0"
+    "@babel/plugin-transform-modules-umd" "^7.2.0"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.4.5"
+    "@babel/plugin-transform-new-target" "^7.4.4"
+    "@babel/plugin-transform-object-super" "^7.5.5"
+    "@babel/plugin-transform-parameters" "^7.4.4"
+    "@babel/plugin-transform-property-literals" "^7.2.0"
+    "@babel/plugin-transform-regenerator" "^7.4.5"
+    "@babel/plugin-transform-reserved-words" "^7.2.0"
+    "@babel/plugin-transform-shorthand-properties" "^7.2.0"
+    "@babel/plugin-transform-spread" "^7.2.0"
+    "@babel/plugin-transform-sticky-regex" "^7.2.0"
+    "@babel/plugin-transform-template-literals" "^7.4.4"
+    "@babel/plugin-transform-typeof-symbol" "^7.2.0"
+    "@babel/plugin-transform-unicode-regex" "^7.4.4"
+    "@babel/types" "^7.5.5"
+    browserslist "^4.6.0"
+    core-js-compat "^3.1.1"
+    invariant "^2.2.2"
+    js-levenshtein "^1.1.3"
+    semver "^5.5.0"
+
 "@babel/preset-env@^7.5.4":
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.5.4.tgz#64bc15041a3cbb0798930319917e70fcca57713d"
@@ -1159,6 +1331,21 @@
     globals "^11.1.0"
     lodash "^4.17.11"
 
+"@babel/traverse@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.5.5.tgz#f664f8f368ed32988cd648da9f72d5ca70f165bb"
+  integrity sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.5.5"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.5.5"
+    "@babel/types" "^7.5.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@7.4.4", "@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0"
@@ -1175,6 +1362,15 @@
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.11"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.5.5.tgz#97b9f728e182785909aa4ab56264f090a028d18a"
+  integrity sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
 "@cnakazawa/watch@^1.0.3":
@@ -2818,7 +3014,7 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*":
+"@types/estree@*", "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
@@ -2987,7 +3183,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^12.6.8":
+"@types/node@*", "@types/node@^12.6.2", "@types/node@^12.6.8":
   version "12.6.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"
   integrity sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==
@@ -3091,6 +3287,13 @@
   version "0.2.28"
   resolved "https://registry.yarnpkg.com/@types/relateurl/-/relateurl-0.2.28.tgz#6bda7db8653fa62643f5ee69e9f69c11a392e3a6"
   integrity sha1-a9p9uGU/piZD9e5p6facEaOS46Y=
+
+"@types/resolve@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
+  integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/serialize-javascript@^1.5.0":
   version "1.5.0"
@@ -4629,6 +4832,11 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+builtin-modules@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
+  integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
 
 builtin-status-codes@^3.0.0:
   version "3.0.0"
@@ -6219,6 +6427,11 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
+ejs@^2.6.1:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.2.tgz#3a32c63d1cd16d11266cd4703b14fec4e74ab4f6"
+  integrity sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q==
+
 electron-to-chromium@^1.3.122:
   version "1.3.133"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.133.tgz#c47639c19b91feee3e22fad69f5556142007008c"
@@ -6511,6 +6724,11 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
   integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
+
+estree-walker@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
+  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
 
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
@@ -8496,6 +8714,11 @@ is-lower-case@^1.1.0:
   dependencies:
     lower-case "^1.1.0"
 
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+  integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
+
 is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
@@ -9664,6 +9887,11 @@ lodash@4.17.14, lodash@^4.17.12, lodash@^4.17.14:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
+lodash@^4.17.13:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
@@ -9753,6 +9981,13 @@ macos-release@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.2.0.tgz#ab58d55dd4714f0a05ad4b0e90f4370fef5cdea8"
   integrity sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA==
+
+magic-string@^0.25.0, magic-string@^0.25.2:
+  version "0.25.3"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.3.tgz#34b8d2a2c7fec9d9bdf9929a3fd81d271ef35be9"
+  integrity sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
 
 make-dir@^1.0.0:
   version "1.3.0"
@@ -11951,7 +12186,7 @@ prettier@^1.18.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
-pretty-bytes@^5.1.0:
+pretty-bytes@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.2.0.tgz#96c92c6e95a0b35059253fb33c03e260d40f5a1f"
   integrity sha512-ujANBhiUsl9AhREUDUEY1GPOharMGm8x8juS7qOHybcLi7XsKfrYQ88hSly1l2i0klXHTDYrlL8ihMCG55Dc3w==
@@ -12916,6 +13151,13 @@ resolve@^1.11.0:
   dependencies:
     path-parse "^1.0.6"
 
+resolve@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
+  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+  dependencies:
+    path-parse "^1.0.6"
+
 responselike@1.0.2, responselike@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
@@ -12970,6 +13212,68 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+rollup-plugin-babel@^4.3.2:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-4.3.3.tgz#7eb5ac16d9b5831c3fd5d97e8df77ba25c72a2aa"
+  integrity sha512-tKzWOCmIJD/6aKNz0H1GMM+lW1q9KyFubbWzGiOG540zxPPifnEAHTZwjo0g991Y+DyOZcLqBgqOdqazYE5fkw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    rollup-pluginutils "^2.8.1"
+
+rollup-plugin-loadz0r@^0.7.1:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-loadz0r/-/rollup-plugin-loadz0r-0.7.2.tgz#0b1ae403a82ee5e5f38ee724ad81799ad2fa4569"
+  integrity sha512-HpjAY9Jqi6fYu1qJxTMjqIMpKzVKxs0ReGTBwR1k7vyu/ikC02qJn62zmhKp+3aOXYB9azFyVbjwzsDJ+XqAVw==
+  dependencies:
+    ejs "^2.6.1"
+    magic-string "^0.25.0"
+
+rollup-plugin-node-resolve@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz#730f93d10ed202473b1fb54a5997a7db8c6d8523"
+  integrity sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
+  dependencies:
+    "@types/resolve" "0.0.8"
+    builtin-modules "^3.1.0"
+    is-module "^1.0.0"
+    resolve "^1.11.1"
+    rollup-pluginutils "^2.8.1"
+
+rollup-plugin-replace@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz#f41ae5372e11e7a217cde349c8b5d5fd115e70e3"
+  integrity sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==
+  dependencies:
+    magic-string "^0.25.2"
+    rollup-pluginutils "^2.6.0"
+
+rollup-plugin-terser@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-5.1.1.tgz#e9d2545ec8d467f96ba99b9216d2285aad8d5b66"
+  integrity sha512-McIMCDEY8EU6Y839C09UopeRR56wXHGdvKKjlfiZG/GrP6wvZQ62u2ko/Xh1MNH2M9WDL+obAAHySljIZYCuPQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    jest-worker "^24.6.0"
+    rollup-pluginutils "^2.8.1"
+    serialize-javascript "^1.7.0"
+    terser "^4.1.0"
+
+rollup-pluginutils@^2.6.0, rollup-pluginutils@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz#8fa6dd0697344938ef26c2c09d2488ce9e33ce97"
+  integrity sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==
+  dependencies:
+    estree-walker "^0.6.1"
+
+rollup@^1.12.3:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.17.0.tgz#47ee8b04514544fc93b39bae06271244c8db7dfa"
+  integrity sha512-k/j1m0NIsI4SYgCJR4MWPstGJOWfJyd6gycKoMhyoKPVXxm+L49XtbUwZyFsrSU2YXsOkM4u1ll9CS/ZgJBUpw==
+  dependencies:
+    "@types/estree" "0.0.39"
+    "@types/node" "^12.6.2"
+    acorn "^6.2.0"
 
 rsvp@^4.8.4:
   version "4.8.4"
@@ -13403,7 +13707,7 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.6, source-map-support@~0.5.10:
+source-map-support@^0.5.6, source-map-support@~0.5.10, source-map-support@~0.5.12:
   version "0.5.12"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
   integrity sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==
@@ -13437,6 +13741,11 @@ source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+sourcemap-codec@^1.4.4:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz#e30a74f0402bad09807640d39e971090a08ce1e9"
+  integrity sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==
 
 space-separated-tokens@^1.0.0:
   version "1.1.3"
@@ -13972,6 +14281,20 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
+temp-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
+  integrity sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=
+
+tempy@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.3.0.tgz#6f6c5b295695a16130996ad5ab01a8bd726e8bf8"
+  integrity sha512-WrH/pui8YCwmeiAoxV+lpRH9HpRtgBhSR2ViBPgpGb/wnYDzp21R4MN45fsCGvLROvY67o3byhJRYRONJyImVQ==
+  dependencies:
+    temp-dir "^1.0.0"
+    type-fest "^0.3.1"
+    unique-string "^1.0.0"
+
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
@@ -14026,6 +14349,15 @@ terser@^4.0.0:
     commander "^2.19.0"
     source-map "~0.6.1"
     source-map-support "~0.5.10"
+
+terser@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.1.2.tgz#b2656c8a506f7ce805a3f300a2ff48db022fa391"
+  integrity sha512-jvNoEQSPXJdssFwqPSgWjsOrb+ELoE+ILpHPKXC83tIxOlh2U75F1KuB2luLD/3a6/7K3Vw5pDn+hvu0C4AzSw==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
 
 test-exclude@^5.2.3:
   version "5.2.3"
@@ -14317,7 +14649,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-fest@^0.3.0:
+type-fest@^0.3.0, type-fest@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
   integrity sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
@@ -14546,7 +14878,7 @@ unzip-response@^2.0.1:
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
   integrity sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=
 
-upath@^1.1.1:
+upath@^1.1.1, upath@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"
   integrity sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
@@ -15059,140 +15391,153 @@ wordwrap@~1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-workbox-background-sync@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/workbox-background-sync/-/workbox-background-sync-4.3.1.tgz#26821b9bf16e9e37fd1d640289edddc08afd1950"
-  integrity sha512-1uFkvU8JXi7L7fCHVBEEnc3asPpiAL33kO495UMcD5+arew9IbKW2rV5lpzhoWcm/qhGB89YfO4PmB/0hQwPRg==
+workbox-background-sync@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/workbox-background-sync/-/workbox-background-sync-5.0.0-alpha.1.tgz#f4f1a4192033dcd6633093ba7a0fe6ce55a6f248"
+  integrity sha512-ttoutvRX47NOl+JaG2bkfEndUpqAY+WOtRgKtLiA1xA43FXY4zS8MwpUV2+H13qkjZ4YdjnKf4u/QGvr1Bpbqw==
   dependencies:
-    workbox-core "^4.3.1"
+    workbox-core "^5.0.0-alpha.1"
 
-workbox-broadcast-update@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/workbox-broadcast-update/-/workbox-broadcast-update-4.3.1.tgz#e2c0280b149e3a504983b757606ad041f332c35b"
-  integrity sha512-MTSfgzIljpKLTBPROo4IpKjESD86pPFlZwlvVG32Kb70hW+aob4Jxpblud8EhNb1/L5m43DUM4q7C+W6eQMMbA==
+workbox-broadcast-update@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/workbox-broadcast-update/-/workbox-broadcast-update-5.0.0-alpha.1.tgz#154e0c2581f04d812bd4dc29718665d1d69f19a2"
+  integrity sha512-fPU9souq2VYEJ1Hjwpw0e559Riv970rCRZvllfIADASiVXR7f4LDwuBVu5SV225dbMMt25apsMfrOeBcKm+QWg==
   dependencies:
-    workbox-core "^4.3.1"
+    workbox-core "^5.0.0-alpha.1"
 
-workbox-build@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/workbox-build/-/workbox-build-4.3.1.tgz#414f70fb4d6de47f6538608b80ec52412d233e64"
-  integrity sha512-UHdwrN3FrDvicM3AqJS/J07X0KXj67R8Cg0waq1MKEOqzo89ap6zh6LmaLnRAjpB+bDIz+7OlPye9iii9KBnxw==
+workbox-build@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/workbox-build/-/workbox-build-5.0.0-alpha.1.tgz#cb3b9fff506165fdc8342a3e24aeaa9376ac0f45"
+  integrity sha512-IGZAkDIxtVzXZKhlTth7RZiGqUi9vFR4rTlgjPylhR3fvHIwQVAzWV5nRaNQSKG6hu/yFXg22K+AiTPymrwy0A==
   dependencies:
+    "@babel/core" "^7.4.5"
+    "@babel/preset-env" "^7.4.5"
     "@babel/runtime" "^7.3.4"
     "@hapi/joi" "^15.0.0"
     common-tags "^1.8.0"
     fs-extra "^4.0.2"
     glob "^7.1.3"
     lodash.template "^4.4.0"
-    pretty-bytes "^5.1.0"
+    pretty-bytes "^5.2.0"
+    rollup "^1.12.3"
+    rollup-plugin-babel "^4.3.2"
+    rollup-plugin-loadz0r "^0.7.1"
+    rollup-plugin-node-resolve "^5.0.0"
+    rollup-plugin-replace "^2.2.0"
+    rollup-plugin-terser "^5.0.0"
     stringify-object "^3.3.0"
     strip-comments "^1.0.2"
-    workbox-background-sync "^4.3.1"
-    workbox-broadcast-update "^4.3.1"
-    workbox-cacheable-response "^4.3.1"
-    workbox-core "^4.3.1"
-    workbox-expiration "^4.3.1"
-    workbox-google-analytics "^4.3.1"
-    workbox-navigation-preload "^4.3.1"
-    workbox-precaching "^4.3.1"
-    workbox-range-requests "^4.3.1"
-    workbox-routing "^4.3.1"
-    workbox-strategies "^4.3.1"
-    workbox-streams "^4.3.1"
-    workbox-sw "^4.3.1"
-    workbox-window "^4.3.1"
+    tempy "^0.3.0"
+    upath "^1.1.2"
+    workbox-background-sync "^5.0.0-alpha.1"
+    workbox-broadcast-update "^5.0.0-alpha.1"
+    workbox-cacheable-response "^5.0.0-alpha.1"
+    workbox-core "^5.0.0-alpha.1"
+    workbox-expiration "^5.0.0-alpha.1"
+    workbox-google-analytics "^5.0.0-alpha.1"
+    workbox-navigation-preload "^5.0.0-alpha.1"
+    workbox-precaching "^5.0.0-alpha.1"
+    workbox-range-requests "^5.0.0-alpha.1"
+    workbox-routing "^5.0.0-alpha.1"
+    workbox-strategies "^5.0.0-alpha.1"
+    workbox-streams "^5.0.0-alpha.1"
+    workbox-sw "^5.0.0-alpha.1"
+    workbox-window "^5.0.0-alpha.1"
 
-workbox-cacheable-response@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/workbox-cacheable-response/-/workbox-cacheable-response-4.3.1.tgz#f53e079179c095a3f19e5313b284975c91428c91"
-  integrity sha512-Rp5qlzm6z8IOvnQNkCdO9qrDgDpoPNguovs0H8C+wswLuPgSzSp9p2afb5maUt9R1uTIwOXrVQMmPfPypv+npw==
+workbox-cacheable-response@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/workbox-cacheable-response/-/workbox-cacheable-response-5.0.0-alpha.1.tgz#51ef72bed237811a411426f641e6c883337c1e86"
+  integrity sha512-//VCe5wLD6pPb5TMSGifUKLBEMBjvW4Us11Swg0rFRzYlr/uMB8GI40nvZmhBNVa52Teg5NdHTVsRUZ/1ixgZg==
   dependencies:
-    workbox-core "^4.3.1"
+    workbox-core "^5.0.0-alpha.1"
 
-workbox-core@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/workbox-core/-/workbox-core-4.3.1.tgz#005d2c6a06a171437afd6ca2904a5727ecd73be6"
-  integrity sha512-I3C9jlLmMKPxAC1t0ExCq+QoAMd0vAAHULEgRZ7kieCdUd919n53WC0AfvokHNwqRhGn+tIIj7vcb5duCjs2Kg==
+workbox-core@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/workbox-core/-/workbox-core-5.0.0-alpha.1.tgz#84ce6b01a0d572722cf8aa3995615bee90126ddf"
+  integrity sha512-RfNmF6/ecaCpCQAfJrGMaQudXpOMdTftZzw+wQkAaCG9JDAUALkUSPdiNrS9x0BLD/gQJ+FPI8w6naYRZqDIWg==
 
-workbox-expiration@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/workbox-expiration/-/workbox-expiration-4.3.1.tgz#d790433562029e56837f341d7f553c4a78ebe921"
-  integrity sha512-vsJLhgQsQouv9m0rpbXubT5jw0jMQdjpkum0uT+d9tTwhXcEZks7qLfQ9dGSaufTD2eimxbUOJfWLbNQpIDMPw==
+workbox-expiration@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/workbox-expiration/-/workbox-expiration-5.0.0-alpha.1.tgz#555d22fea5eca46a7b7928a843d87b462904a8f2"
+  integrity sha512-d2NfFYFeE+L+tvPaqTHCn8Wn6L6OEIiLwydvsoUjos6TOczsRckGTYdtAFSsTIvhzP5sY7LLXlQnWTbb751mrw==
   dependencies:
-    workbox-core "^4.3.1"
+    workbox-core "^5.0.0-alpha.1"
 
-workbox-google-analytics@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/workbox-google-analytics/-/workbox-google-analytics-4.3.1.tgz#9eda0183b103890b5c256e6f4ea15a1f1548519a"
-  integrity sha512-xzCjAoKuOb55CBSwQrbyWBKqp35yg1vw9ohIlU2wTy06ZrYfJ8rKochb1MSGlnoBfXGWss3UPzxR5QL5guIFdg==
+workbox-google-analytics@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/workbox-google-analytics/-/workbox-google-analytics-5.0.0-alpha.1.tgz#d0b7d2b73af7837e2cb0668b7ca7875ba2af9828"
+  integrity sha512-ntsCEykEWhxFEc/NnpVV1LGgpQBOzooyr6vCo0Eb+1Nir1doqFbisfsMK8Q4ANhit9sb6GUnHN+kg230USYjDQ==
   dependencies:
-    workbox-background-sync "^4.3.1"
-    workbox-core "^4.3.1"
-    workbox-routing "^4.3.1"
-    workbox-strategies "^4.3.1"
+    workbox-background-sync "^5.0.0-alpha.1"
+    workbox-core "^5.0.0-alpha.1"
+    workbox-routing "^5.0.0-alpha.1"
+    workbox-strategies "^5.0.0-alpha.1"
 
-workbox-navigation-preload@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/workbox-navigation-preload/-/workbox-navigation-preload-4.3.1.tgz#29c8e4db5843803b34cd96dc155f9ebd9afa453d"
-  integrity sha512-K076n3oFHYp16/C+F8CwrRqD25GitA6Rkd6+qAmLmMv1QHPI2jfDwYqrytOfKfYq42bYtW8Pr21ejZX7GvALOw==
+workbox-navigation-preload@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/workbox-navigation-preload/-/workbox-navigation-preload-5.0.0-alpha.1.tgz#d7daa5341d7ef78cf53f0d8b7ec2a54a025c5a69"
+  integrity sha512-BBeOV4xUqiE64w/afviCzaUdVmQ4SrmuXASxMv2wi+Aju+cp6YfZ7KcKVcHxhQEqfJ7m/5K7dTNta8lig0ajcw==
   dependencies:
-    workbox-core "^4.3.1"
+    workbox-core "^5.0.0-alpha.1"
 
-workbox-precaching@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/workbox-precaching/-/workbox-precaching-4.3.1.tgz#9fc45ed122d94bbe1f0ea9584ff5940960771cba"
-  integrity sha512-piSg/2csPoIi/vPpp48t1q5JLYjMkmg5gsXBQkh/QYapCdVwwmKlU9mHdmy52KsDGIjVaqEUMFvEzn2LRaigqQ==
+workbox-precaching@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/workbox-precaching/-/workbox-precaching-5.0.0-alpha.1.tgz#c1397aa98d5067a5c6d59a227d5a5705813d064b"
+  integrity sha512-Sc9wzE6yeJX8BTHzDl12BpKBTl4TT/b1q+HVnFQz5tSC4BqUuExEPGDpZ/b3cOJUiFRnEpn5P0nTd1arUQIDcg==
   dependencies:
-    workbox-core "^4.3.1"
+    workbox-core "^5.0.0-alpha.1"
 
-workbox-range-requests@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/workbox-range-requests/-/workbox-range-requests-4.3.1.tgz#f8a470188922145cbf0c09a9a2d5e35645244e74"
-  integrity sha512-S+HhL9+iTFypJZ/yQSl/x2Bf5pWnbXdd3j57xnb0V60FW1LVn9LRZkPtneODklzYuFZv7qK6riZ5BNyc0R0jZA==
+workbox-range-requests@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/workbox-range-requests/-/workbox-range-requests-5.0.0-alpha.1.tgz#b36b1a7ce78542881f6952fd83a035abad9e5a5a"
+  integrity sha512-EZNaEIFVwDQr8HZLf6kZRCWFgPxxycdkjEr7F44gzN1QrEa86okVB4nnFVbRM68U8nqWFQKb8sUMTX9L6L41dg==
   dependencies:
-    workbox-core "^4.3.1"
+    workbox-core "^5.0.0-alpha.1"
 
-workbox-routing@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/workbox-routing/-/workbox-routing-4.3.1.tgz#a675841af623e0bb0c67ce4ed8e724ac0bed0cda"
-  integrity sha512-FkbtrODA4Imsi0p7TW9u9MXuQ5P4pVs1sWHK4dJMMChVROsbEltuE79fBoIk/BCztvOJ7yUpErMKa4z3uQLX+g==
+workbox-routing@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/workbox-routing/-/workbox-routing-5.0.0-alpha.1.tgz#5c73153835a54219de53cdd2174e387bea7e4bee"
+  integrity sha512-2mVzxn369DzKwXKOKF7lR/Kd7ZSiJVHBKojB42IlCT/RaFXrLlr5A6promEYNhReeE2pUecZx9LzMcjZAq4WpA==
   dependencies:
-    workbox-core "^4.3.1"
+    workbox-core "^5.0.0-alpha.1"
 
-workbox-strategies@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/workbox-strategies/-/workbox-strategies-4.3.1.tgz#d2be03c4ef214c115e1ab29c9c759c9fe3e9e646"
-  integrity sha512-F/+E57BmVG8dX6dCCopBlkDvvhg/zj6VDs0PigYwSN23L8hseSRwljrceU2WzTvk/+BSYICsWmRq5qHS2UYzhw==
+workbox-strategies@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/workbox-strategies/-/workbox-strategies-5.0.0-alpha.1.tgz#3ca58e4d8954226b23833ce9b4a843e02170ea2d"
+  integrity sha512-hEtlBfy68BCqlWkPeWMcb9FDhl1X8hJ93eNUrcI2UZbdIDncse/j7xycEbcUfWFgAQ+h/+hsy37x06J/n+wgUw==
   dependencies:
-    workbox-core "^4.3.1"
+    workbox-core "^5.0.0-alpha.1"
+    workbox-routing "^5.0.0-alpha.1"
 
-workbox-streams@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/workbox-streams/-/workbox-streams-4.3.1.tgz#0b57da70e982572de09c8742dd0cb40a6b7c2cc3"
-  integrity sha512-4Kisis1f/y0ihf4l3u/+ndMkJkIT4/6UOacU3A4BwZSAC9pQ9vSvJpIi/WFGQRH/uPXvuVjF5c2RfIPQFSS2uA==
+workbox-streams@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/workbox-streams/-/workbox-streams-5.0.0-alpha.1.tgz#eb295ed7ad7bcd08a5bf9867172cc79a888c159e"
+  integrity sha512-ECW+lkGumXixKznFPVGCknEUaMdMhSNYgs9xGEXK7svbxqCWNRFP235KtQKDGLMANLlRmtv2kxCVOZSd2UwKZQ==
   dependencies:
-    workbox-core "^4.3.1"
+    workbox-core "^5.0.0-alpha.1"
+    workbox-routing "^5.0.0-alpha.1"
 
-workbox-sw@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/workbox-sw/-/workbox-sw-4.3.1.tgz#df69e395c479ef4d14499372bcd84c0f5e246164"
-  integrity sha512-0jXdusCL2uC5gM3yYFT6QMBzKfBr2XTk0g5TPAV4y8IZDyVNDyj1a8uSXy3/XrvkVTmQvLN4O5k3JawGReXr9w==
+workbox-sw@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/workbox-sw/-/workbox-sw-5.0.0-alpha.1.tgz#01cb53aea3c60fbe82ceffdd258827139a5717b2"
+  integrity sha512-0EUyACd7clxvFhEHUqXm2mZbK17j84tjGJVKSoWa1TTSh0yNlkPrkW2Gh+Sn0o9hrc+sStqC9POh9yJd5VGsDw==
 
-workbox-webpack-plugin@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/workbox-webpack-plugin/-/workbox-webpack-plugin-4.3.1.tgz#47ff5ea1cc074b6c40fb5a86108863a24120d4bd"
-  integrity sha512-gJ9jd8Mb8wHLbRz9ZvGN57IAmknOipD3W4XNE/Lk/4lqs5Htw4WOQgakQy/o/4CoXQlMCYldaqUg+EJ35l9MEQ==
+workbox-webpack-plugin@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/workbox-webpack-plugin/-/workbox-webpack-plugin-5.0.0-alpha.1.tgz#0f1dbe376ae5f15738eb63c76622b67c5757a052"
+  integrity sha512-wJM0ZZwbSAE7KvfKoIblgnP1oCY38rTHExlfljgOIp+K05a/GzcjV/jvfAR/8cug4+TGdx9AsIbXCcAjpTmB8g==
   dependencies:
     "@babel/runtime" "^7.0.0"
     json-stable-stringify "^1.0.1"
-    workbox-build "^4.3.1"
+    webpack-sources "^1.3.0"
+    workbox-build "^5.0.0-alpha.1"
 
-workbox-window@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/workbox-window/-/workbox-window-4.3.1.tgz#ee6051bf10f06afa5483c9b8dfa0531994ede0f3"
-  integrity sha512-C5gWKh6I58w3GeSc0wp2Ne+rqVw8qwcmZnQGpjiek8A2wpbxSJb1FdCoQVO+jDJs35bFgo/WETgl1fqgsxN0Hg==
+workbox-window@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/workbox-window/-/workbox-window-5.0.0-alpha.1.tgz#c48e121d224eb2e3d88ed20a476d3f427a22d71d"
+  integrity sha512-oB1H2W9spT8f/IUkqhWG/0/KO3QJ9d+5IOx2hZ8IaqNADjxHBmWrV7DxDEMLkDvpjkOdFh6WkGTCqUNJEovPIg==
   dependencies:
-    workbox-core "^4.3.1"
+    workbox-core "^5.0.0-alpha.1"
 
 worker-farm@^1.5.2, worker-farm@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
update the workbox plugin to `InjectManifest` in order to get rid of debug logs and upgrades the packages versions to the v5 alpha, so the service worker source is compiled by webpack.